### PR TITLE
Pass mirte_slam_param to slam_toolbox

### DIFF
--- a/launch/robot_navigation.launch.py
+++ b/launch/robot_navigation.launch.py
@@ -44,6 +44,11 @@ def generate_launch_description():
         'params',
         'mirte_nav2_params.yaml')
 
+    slam_params_file = os.path.join(
+        pkg_mirte_navigation,
+        'params',
+        'mirte_slam_params.yaml')
+
     # Localization launch
     localization_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(PathJoinSubstitution([
@@ -70,7 +75,13 @@ def generate_launch_description():
     nav2_with_slam = GroupAction(
         actions=[
             navigation_launch,
-            IncludeLaunchDescription(AnyLaunchDescriptionSource(slam_tb_launch_path)),
+            IncludeLaunchDescription(
+                AnyLaunchDescriptionSource(slam_tb_launch_path),
+                launch_arguments = {
+                    'slam_params_file': slam_params_file,
+                    'use_sim_time': use_sim_time,
+                }.items()
+            ),
         ],
         condition=LaunchConfigurationEquals("use_map", "False"),
     )

--- a/params/mirte_slam_params.yaml
+++ b/params/mirte_slam_params.yaml
@@ -1,0 +1,77 @@
+slam_toolbox:
+  ros__parameters:
+
+    # Plugin params
+    solver_plugin: solver_plugins::CeresSolver
+    ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
+    ceres_preconditioner: SCHUR_JACOBI
+    ceres_trust_strategy: LEVENBERG_MARQUARDT
+    ceres_dogleg_type: TRADITIONAL_DOGLEG
+    ceres_loss_function: None
+
+    # ROS Parameters
+    odom_frame: odom
+    map_frame: map
+    base_frame: base_link
+    scan_topic: /scan
+    use_map_saver: true
+    mode: mapping #localization
+
+    # if you'd like to immediately start continuing a map at a given pose
+    # or at the dock, but they are mutually exclusive, if pose is given
+    # will use pose
+    #map_file_name: test_steve
+    # map_start_pose: [0.0, 0.0, 0.0]
+    #map_start_at_dock: true
+
+    debug_logging: false
+    throttle_scans: 1
+    transform_publish_period: 0.02 #if 0 never publishes odometry
+    map_update_interval: 5.0
+    resolution: 0.05
+    min_laser_range: 0.0 #for rastering images
+    max_laser_range: 20.0 #for rastering images
+    minimum_time_interval: 0.5
+    transform_timeout: 0.2
+    tf_buffer_duration: 30.
+    stack_size_to_use: 40000000 #// program needs a larger stack size to serialize large maps
+    enable_interactive_mode: true
+
+    # General Parameters
+    use_scan_matching: true
+    use_scan_barycenter: true
+    minimum_travel_distance: 0.5
+    minimum_travel_heading: 0.5
+    scan_buffer_size: 10
+    scan_buffer_maximum_scan_distance: 10.0
+    link_match_minimum_response_fine: 0.1  
+    link_scan_maximum_distance: 1.5
+    loop_search_maximum_distance: 3.0
+    do_loop_closing: true 
+    loop_match_minimum_chain_size: 10           
+    loop_match_maximum_variance_coarse: 3.0  
+    loop_match_minimum_response_coarse: 0.35    
+    loop_match_minimum_response_fine: 0.45
+
+    # Correlation Parameters - Correlation Parameters
+    correlation_search_space_dimension: 0.5
+    correlation_search_space_resolution: 0.01
+    correlation_search_space_smear_deviation: 0.1 
+
+    # Correlation Parameters - Loop Closure Parameters
+    loop_search_space_dimension: 8.0
+    loop_search_space_resolution: 0.05
+    loop_search_space_smear_deviation: 0.03
+
+    # Scan Matcher Parameters
+    distance_variance_penalty: 0.5      
+    angle_variance_penalty: 1.0    
+
+    fine_search_angle_offset: 0.00349     
+    coarse_search_angle_offset: 0.349   
+    coarse_angle_resolution: 0.0349        
+    minimum_angle_penalty: 0.9
+    minimum_distance_penalty: 0.5
+    use_response_expansion: true
+    min_pass_through: 2
+    occupancy_threshold: 0.1


### PR DESCRIPTION
By default, slam_toolbox expects the robot_frame to be `base_footprint`. That is why mapping was only working when running the localization pkg as well. I added a new param file with the robot_frame set to base_link

By the way, I think we can merge the fortress branch into main since it doesn't have anything specific to the simulation. 